### PR TITLE
feat: added @callerSrc() builtin

### DIFF
--- a/lib/std/zig/AstRlAnnotate.zig
+++ b/lib/std/zig/AstRlAnnotate.zig
@@ -873,6 +873,7 @@ fn builtinCall(astrl: *AstRlAnnotate, block: ?*Block, ri: ResultInfo, node: Ast.
         },
         // These builtins take no args and do not consume the result pointer.
         .src,
+        .caller_src,
         .This,
         .return_address,
         .error_return_trace,

--- a/lib/std/zig/BuiltinFn.zig
+++ b/lib/std/zig/BuiltinFn.zig
@@ -93,6 +93,7 @@ pub const Tag = enum {
     splat,
     reduce,
     src,
+    caller_src,
     sqrt,
     sin,
     cos,
@@ -818,6 +819,14 @@ pub const list = list: {
             .{
                 .tag = .src,
                 .needs_mem_loc = .always,
+                .param_count = 0,
+                .illegal_outside_function = true,
+            },
+        },
+        .{
+            "@callerSrc",
+            .{
+                .tag = .caller_src,
                 .param_count = 0,
                 .illegal_outside_function = true,
             },

--- a/src/AstGen.zig
+++ b/src/AstGen.zig
@@ -8486,6 +8486,7 @@ fn builtinCall(
         .frame_address      => return rvalue(gz, ri, try gz.addNodeExtended(.frame_address,      node), node),
         .breakpoint         => return rvalue(gz, ri, try gz.addNodeExtended(.breakpoint,         node), node),
         .in_comptime        => return rvalue(gz, ri, try gz.addNodeExtended(.in_comptime,        node), node),
+        .caller_src         => return rvalue(gz, ri, try gz.addNodeExtended(.builtin_caller_src, node), node),
 
         .type_info   => return simpleUnOpType(gz, scope, ri, node, params[0], .type_info),
         .size_of     => return simpleUnOpType(gz, scope, ri, node, params[0], .size_of),

--- a/src/Zir.zig
+++ b/src/Zir.zig
@@ -1920,6 +1920,9 @@ pub const Inst = struct {
         /// Implements the `@src` builtin.
         /// `operand` is payload index to `LineColumn`.
         builtin_src,
+        /// Implements the `@callerSrc` builtin.
+        /// `operand` is `src_node: i32`.
+        builtin_caller_src,
         /// Implements the `@errorReturnTrace` builtin.
         /// `operand` is `src_node: i32`.
         error_return_trace,

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -537,6 +537,7 @@ const Writer = struct {
             .c_va_start,
             .in_comptime,
             .value_placeholder,
+            .builtin_caller_src,
             => try self.writeExtNode(stream, extended),
 
             .builtin_src => {

--- a/test/behavior/caller_src.zig
+++ b/test/behavior/caller_src.zig
@@ -1,0 +1,14 @@
+const std = @import("std");
+
+fn callerSrcReporter() std.builtin.SourceLocation {
+    const caller = @callerSrc();
+    return caller;
+}
+
+test "@callerSrc() behavior" {
+    const loc = callerSrcReporter();
+
+    try std.testing.expectEqual(@as(usize, 9), loc.line);
+    try std.testing.expectEqual(@as(usize, 17), loc.column);
+    try std.testing.expectEqualStrings("test.@callerSrc() behavior", loc.fn_name);
+}


### PR DESCRIPTION
This builtin returns a `std.builtin.SourceLocation` containing the location of the call site at comptime.

This can be leveraged by library authors to pinpoints invalid use of their API.